### PR TITLE
Fix null reference Edge error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const detectPassiveEvents = {
       const options = Object.defineProperty({}, 'passive', {
         get() { passive = true; },
       });
-      window.addEventListener('test', null, options);
+      window.addEventListener('test', () => {}, options);
 
       detectPassiveEvents.hasSupport = passive;
     }


### PR DESCRIPTION
`addEventListener`method should not register a null callback as it trigger the following error in Edge:

Unable to get property 'handleEvent' of undefined or null reference